### PR TITLE
Trigger CI when pushing to english branch

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - sp_en_branch
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
This PR adds `sp_en_branch` to the trigger list for the CI, so that the CI runs when we push to the english branch, not just master (macedonian branch).

Changes:
 - Add `sp_en_branch` to the CI push trigger